### PR TITLE
Commit the `.env` file for other developers

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -81,7 +81,7 @@ Session.vim
 # Miscellaneous
 #
 
-.env
+.env.local
 
 # Google App Engine generated folder
 appengine-generated/


### PR DESCRIPTION
Versioning the `.env` is good practice as it saves from having to set defaults directly
in the code and document them elsewhere. Projects should support overriding the
values by ones found in `.env.local` instead.